### PR TITLE
Associate metrics with users. Only allow users to edit or destroy their own metrics.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :authenticate_user!
 
   protected
 

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -17,6 +17,7 @@ class MetricsController < ApplicationController
 
   def create
     @metric = Metric.new(metric_params)
+    @metric.user_id = current_user.id
 
     respond_to do |format|
       if @metric.save
@@ -30,22 +31,30 @@ class MetricsController < ApplicationController
   end
 
   def update
-    respond_to do |format|
-      if @metric.update(metric_params)
-        format.html { redirect_to @metric, notice: 'Metric was successfully updated.' }
-        format.json { render :show, status: :ok, location: @metric }
-      else
-        format.html { render :edit }
-        format.json { render json: @metric.errors, status: :unprocessable_entity }
+    if @metric.user == current_user
+      respond_to do |format|
+        if @metric.update(metric_params)
+          format.html { redirect_to @metric, notice: 'Metric was successfully updated.' }
+          format.json { render :show, status: :ok, location: @metric }
+        else
+          format.html { render :edit }
+          format.json { render json: @metric.errors, status: :unprocessable_entity }
+        end
       end
+    else
+      redirect_to root_path, notice: 'You can only edit your own metrics.' 
     end
   end
 
   def destroy
-    @metric.destroy
-    respond_to do |format|
-      format.html { redirect_to metrics_url, notice: 'Metric was successfully destroyed.' }
-      format.json { head :no_content }
+    if @metric.user == current_user
+      @metric.destroy
+      respond_to do |format|
+        format.html { redirect_to metrics_url, notice: 'Metric was successfully destroyed.' }
+        format.json { head :no_content }
+      end
+    else
+      redirect_to root_path, notice: 'You can only delete your own metrics.'
     end
   end
 

--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -1,2 +1,3 @@
 class Metric < ActiveRecord::Base
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  has_many :metrics
 
   validates_with EmailValidator
 

--- a/db/migrate/20160503184017_add_user_to_metrics.rb
+++ b/db/migrate/20160503184017_add_user_to_metrics.rb
@@ -1,0 +1,5 @@
+class AddUserToMetrics < ActiveRecord::Migration
+  def change
+    add_reference :metrics, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160421221827) do
+ActiveRecord::Schema.define(version: 20160503184017) do
 
   create_table "metrics", force: :cascade do |t|
     t.string   "name"
     t.string   "definition"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer  "user_id"
   end
+
+  add_index "metrics", ["user_id"], name: "index_metrics_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false


### PR DESCRIPTION
Fixes #8 (has_many & belongs_to for metric & user) & #9 (users can only update or destroy their own metrics) #10 is solved (already the default behavior). Also fixes #14 by adding before_action :authenticate_user! to application_controller.
